### PR TITLE
add .gcloudignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile*
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
@@ -130,3 +130,4 @@ dmypy.json
 
 # sensitive information
 test-python-etl-*.json
+

--- a/fetch_data/.gcloudignore
+++ b/fetch_data/.gcloudignore
@@ -1,0 +1,3 @@
+.env
+Pipfile*
+test-python-*.json


### PR DESCRIPTION
For Google Cloud Function, we need to deploy only main.py and requirements.txt. Ignore everything except main.py and requirements.txt.