### PR TITLE
modularize fetch_data function for GCP deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 # sensitive information
 test-python-etl-*.json
 
+
+.vscode/

--- a/fetch_data/fetch_data.py
+++ b/fetch_data/fetch_data.py
@@ -20,7 +20,7 @@ def store_data(data):
     except Exception as e:
         print(str(e))
 
-def main():
+def fetch_and_store():
     url = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv'
     data_fetched = fetch_data(url)
     store_data(data_fetched)

--- a/fetch_data/main.py
+++ b/fetch_data/main.py
@@ -5,8 +5,6 @@ from dotenv import load_dotenv
 load_dotenv()
 import os
 
-url = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv'
-
 def fetch_data(input):
     data = requests.get(input)
     return data.text
@@ -22,5 +20,7 @@ def store_data(data):
     except Exception as e:
         print(str(e))
 
-data_fetched = fetch_data(url)
-store_data(data_fetched)
+def main():
+    url = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv'
+    data_fetched = fetch_data(url)
+    store_data(data_fetched)

--- a/fetch_data/requirements.txt
+++ b/fetch_data/requirements.txt
@@ -1,2 +1,3 @@
-requests==2.23.0
-python-dotenv==0.12.0
+requests
+python-dotenv
+google-cloud-storage

--- a/main.py
+++ b/main.py
@@ -1,0 +1,3 @@
+from fetch_data.fetch_data import fetch_and_store
+
+fetch_and_store()


### PR DESCRIPTION
resolves #6 

Currently the main.py file within the fetch_data folder calls its own main() function. This makes GCP angry. GCP does not do things that way.

This PR puts the call to store_data and fetch_data inside a function fetch_and_store. Then GCP will run this function coz we tell it to.