### PR TITLE
more fixes for deploying to GCP

### DIFF
--- a/fetch_data/.gcloudignore
+++ b/fetch_data/.gcloudignore
@@ -1,3 +1,4 @@
 .env
 Pipfile*
 test-python-*.json
+__init__.py

--- a/fetch_data/main.py
+++ b/fetch_data/main.py
@@ -20,7 +20,7 @@ def store_data(data):
     except Exception as e:
         print(str(e))
 
-def fetch_and_store():
+def fetch_and_store(event, context):
     url = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv'
     data_fetched = fetch_data(url)
     store_data(data_fetched)

--- a/main.py
+++ b/main.py
@@ -1,3 +1,3 @@
-from fetch_data.fetch_data import fetch_and_store
+from fetch_data.main import fetch_and_store
 
-fetch_and_store()
+fetch_and_store(None, None)


### PR DESCRIPTION
1. GCP expects the entry point file to be called main.py
2. GCP Pub/Sub triggers pass two arguments to the called function: `event` and `context`. Apparently Python gets mad if you pass arguments to a function that the function does not expect. Also it gets mad if you _don't_ pass args to a function that is expecting them. Who knew? 🤷🏻‍♂️ This ain't JavaScript.

This PR renames the entry point file, and gives the entry point function two args, which it does not do anything with.